### PR TITLE
Updated to Pylon 6.3.0/6.2.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,10 @@ build_binaries:
     paths:
       - products/*.tar.gz
       - .julia/dev/
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - .julia/artifacts/
 
 .install_pylon:
   before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM julia:1.6-buster
 
 COPY src/install_pylon.sh /project/src/install_pylon.sh
 RUN bash /project/src/install_pylon.sh
-ENV PYLON_INCLUDE_PATH /opt/pylon5/include
-ENV PYLON_LIB_PATH /opt/pylon5/lib64
+ENV PYLON_INCLUDE_PATH /opt/pylon/include
+ENV PYLON_LIB_PATH /opt/pylon/lib
 
 COPY . /project
 WORKDIR /project

--- a/binary_builder/build_tarballs.jl
+++ b/binary_builder/build_tarballs.jl
@@ -17,13 +17,11 @@ sources = [
 
 julia_version = v"1.6.0"
 
-pylon_version = "5.1.0.12682"
-pylon_sha1sum = "db866bea9d8a8273d8b85cc331fa77b95bae4c83"
+pylon_version = "6.3.0.23157"
+pylon_sha1sum = "2425bb97a27c09b498775435d99ade7379ed8b44"
 
-# pylon_version = "5.2.0.13457"
-
-pylon_macos_version = "5.1.1.13069"
-pylon_macos_sha1sum = "140234a603b5a8b0b9ff0aa725dcaedbdff2908d"
+pylon_macos_version = "6.2.0.21487"
+pylon_macos_sha1sum = "75f990a4a1fe5644faf1ef464aa555b386eb113e"
 
 basler_web_time_limit = round(Int, time()) + 24*60*60
 
@@ -34,28 +32,28 @@ cd \$WORKSPACE
 mkdir downloads && cd downloads
 
 if [[ \${target} == *linux* ]]; then
-    curl https://www.baslerweb.com/fp-$basler_web_time_limit/media/downloads/software/pylon_software/pylon-$pylon_version-x86_64.tar.gz -O
-    echo "$pylon_sha1sum  pylon-$pylon_version-x86_64.tar.gz" | sha1sum -c -w
-    tar xfz pylon-$pylon_version-x86_64.tar.gz
-    cd pylon-$pylon_version-x86_64
-    tar xfz pylonSDK*.tar.gz
+    curl https://www.baslerweb.com/fp-$basler_web_time_limit/media/downloads/software/pylon_software/pylon_$(pylon_version)_x86_64_setup.tar.gz -O
+    echo "$pylon_sha1sum  pylon_$(pylon_version)_x86_64_setup.tar.gz" | sha1sum -c -w
+    tar xfz pylon_$(pylon_version)_x86_64_setup.tar.gz
+    tar xfz pylon_$(pylon_version)_x86_64.tar.gz
 
-    export PYLON_INCLUDE_PATH=`pwd`/pylon5/include
-    export PYLON_LIB_PATH=`pwd`/pylon5/lib64
+    export PYLON_INCLUDE_PATH=`pwd`/include
+    export PYLON_LIB_PATH=`pwd`/lib
 
-    cp -av \${PYLON_LIB_PATH}/ \$WORKSPACE/destdir/lib64
+    rm -rf lib/pylonCXP lib/pylonviewer lib/Qt
+    cp -av lib \$WORKSPACE/destdir/
 
-    install_license pylon5/share/pylon/License.html
-    install_license pylon5/share/pylon/pylon_Third-Party_Licenses.html
+    install_license share/pylon/licenses/License.html
+    install_license share/pylon/licenses/pylon_Third-Party_Licenses.html
 elif [[ \${target} == *apple* ]]; then
     curl https://www.baslerweb.com/fp-$basler_web_time_limit/media/downloads/software/pylon_software/pylon-$pylon_macos_version.dmg -O
     echo "$pylon_macos_sha1sum  pylon-$pylon_macos_version.dmg" | sha1sum -c -w
     apk update && apk add p7zip && apk add libarchive-tools
     7z x pylon-$pylon_macos_version.dmg
-    mv \"pylon 5 Camera Software Suite\" pylon-$(pylon_macos_version)
+    mv \"pylon $pylon_macos_version Camera Software Suite\" pylon-$(pylon_macos_version)
     cd pylon-$(pylon_macos_version)
     7z x pylon-$pylon_macos_version.pkg
-    gunzip -c pylonsdk.pkg/Payload | bsdcpio -i --no-preserve-owner
+    gunzip -c pylon_core_framework.pkg/Payload | bsdcpio -i --no-preserve-owner
 
     cp -av Library/Frameworks/pylon.framework \$WORKSPACE/destdir/lib/
 
@@ -86,10 +84,9 @@ VERBOSE=ON cmake --build . --config Release --target install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Platform("x86_64", "linux"; julia_version=string(julia_version)),
+    Platform("x86_64", "linux"; cxxstring_abi="cxx11", julia_version=string(julia_version)),
     Platform("x86_64", "macos"; julia_version=string(julia_version))
 ]
-platforms = expand_cxxstring_abis(platforms)
 
 # The products that we will ensure are always built
 products = [

--- a/src/install_pylon.sh
+++ b/src/install_pylon.sh
@@ -7,20 +7,17 @@ install_pylon_on_debian()
 
     DEBIAN_FRONTEND=noninteractive apt-get install -y usbutils cmake clang
 
-    PYLON_VERSION=5.1.0.12682
-    PYLON_SHA1SUM=2e051aa9e6470dc22eeb6069514c845f3dff4752
-
-    #PYLON_VERSION 5.2.0.13457
-    #PYLON_SHA1SUM 4886c00219226e7f3334bd580c8c37791422cc41
+    PYLON_VERSION=6.3.0.23157
+    PYLON_SHA1SUM=e34ce2d18afda78611ba1d761b375a5d0ebd212a
 
     TIME_LIMIT=`echo $(($(date +%s) + 24*60*60))`
     curl https://www.baslerweb.com/fp-${TIME_LIMIT}/media/downloads/software/pylon_software/pylon_${PYLON_VERSION}-deb0_amd64.deb -O
     echo "${PYLON_SHA1SUM} pylon_${PYLON_VERSION}-deb0_amd64.deb" | sha1sum -c
     DEBIAN_FRONTEND=noninteractive dpkg -i pylon_${PYLON_VERSION}-deb0_amd64.deb
     rm -f pylon_${PYLON_VERSION}-deb0_amd64.deb
-    export PATH=/opt/pylon5/bin:$PATH
-    export PYLON_INCLUDE_PATH=/opt/pylon5/include
-    export PYLON_LIB_PATH=/opt/pylon5/lib64
+    export PATH=/opt/pylon/bin:$PATH
+    export PYLON_INCLUDE_PATH=/opt/pylon/include
+    export PYLON_LIB_PATH=/opt/pylon/lib
 }
 
 install_pylon_on_debian


### PR DESCRIPTION
* Restricted Linux build to cxx11 string ABI.
* Omitted pylonCXP libraries.
* GitLab CI: Adding caching of BinaryBuilder artifacts.